### PR TITLE
Add templatable fields to weather widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,41 +66,41 @@ espaper_dashboard: # component name
 Specific configuration:
 
 - **temperature_uom** (*Optional*, `string`): The unit of measurement for the temperature. Defaults to `°C`.
-- **current_temperature_sensor_id** (**Required**, [Sensor](https://esphome.io/components/sensor/)): The ID of a `Sensor` containing the current temperature.
-- **current_condition_sensor_id** (**Required**, [TextSensor](https://esphome.io/components/text_sensor)): The ID of a `TextSensor` containing the current weather condition, which must be one of [these values](https://developers.home-assistant.io/docs/core/entity/weather#recommended-values-for-state-and-condition).
-- **forecast_sensor_id** (**Required**, [TextSensor](https://esphome.io/components/text_sensor)): The ID of a `TextSensor` containing a JSON with the forecast. The mandatory format of the JSON is:
-  - **forecast**: a list of objects containing forcasts. The max size of the list is hard-coded to 5. Each forecast item contains
-    - **label**: a string which designates the timeframe that the forecast describes (e.g. `23:00` or `Tuesday`)
+- **current_temperature** (**Required**, [templatable](https://esphome.io/automations/templates#config-templatable)): The current temperature to display
+- **current_condition** (**Required**, [templatable](https://esphome.io/automations/templates#config-templatable)): The current weather condition, which must be one of [these values](https://developers.home-assistant.io/docs/core/entity/weather#recommended-values-for-state-and-condition).
+- **forecast** (**Required**, [templatable](https://esphome.io/automations/templates#config-templatable)): A list of objects with the forecast. The mandatory format of each object is:
+  - **forecast**: a list of objects containing forcasts as `WeatherStatus` objects. Each forecast item contains
+    - **title**: a string which designates the timeframe that the forecast describes (e.g. `23:00` or `Tuesday`)
     - **condition**: a string [from this list](https://developers.home-assistant.io/docs/core/entity/weather#recommended-values-for-state-and-condition) containing the weather condition
     - **temperature**: a numeric value representing the temperature for the forecast
 
-Here's an example `forecast` text sensor content:
+Here's an example `forecast` list:
 
-```json
-{
-  "forecast": [
-    {
-      "condition": "sunny",
-      "label": "12:00",
-      "temperature": 26.7
-    },
-    {
-      "condition": "sunny",
-      "label": "14:00",
-      "temperature": 28.5
-    },
-    {
-      "condition": "sunny",
-      "label": "16:00",
-      "temperature": 29.2
-    },
-    {
-      "condition": "partlycloudy",
-      "label": "18:00",
-      "temperature": 28.3
-    }
-  ]
-}
+```yaml
+espaper_dashboard:
+  widgets:
+    - type: weather
+      forecast:
+        - condition: "sunny"
+          label: "12:00"
+          temperature: 26.7
+        - condition: "sunny"
+          label: "14:00"
+          temperature: 28.5
+        - condition: "sunny"
+          label: "16:00"
+          temperature: 29.2
+        - condition: "partlycloudy"
+          label: "18:00"
+          temperature: 28.3
+    - type: weather
+      forecast: !lambda |-
+        return std::vector<espaper_dashboard_widgets::WeatherStatus> {
+          espaper_dashboard_widgets::WeatherStatus("12:00", 26.7, "sunny"),
+          espaper_dashboard_widgets::WeatherStatus("14:00", 28.5, "sunny"),
+          espaper_dashboard_widgets::WeatherStatus("16:00", 29.2, "sunny"),
+          espaper_dashboard_widgets::WeatherStatus("18:00", 28.3, "partlycloudy")
+        };
 ```
 
 You can create such a sensor from HA using a template such as
@@ -130,22 +130,22 @@ template:
           forecast: >-
             {% set forecast_attr = [
               {
-                "label": as_timestamp(forecast['weather.home'].forecast[1].datetime) | timestamp_custom("%H:00"),
+                "title": as_timestamp(forecast['weather.home'].forecast[1].datetime) | timestamp_custom("%H:00"),
                 "condition": forecast['weather.home'].forecast[1].condition,
                 "temperature": forecast['weather.home'].forecast[1].temperature,
               },
               {
-                "label": as_timestamp(forecast['weather.home'].forecast[3].datetime) | timestamp_custom("%H:00"),
+                "title": as_timestamp(forecast['weather.home'].forecast[3].datetime) | timestamp_custom("%H:00"),
                 "condition": forecast['weather.home'].forecast[3].condition,
                 "temperature": forecast['weather.home'].forecast[3].temperature,
               },
               {
-                "label": as_timestamp(forecast['weather.home'].forecast[5].datetime) | timestamp_custom("%H:00"),
+                "title": as_timestamp(forecast['weather.home'].forecast[5].datetime) | timestamp_custom("%H:00"),
                 "condition": forecast['weather.home'].forecast[5].condition,
                 "temperature": forecast['weather.home'].forecast[5].temperature,
               },
               {
-                "label": as_timestamp(forecast['weather.home'].forecast[7].datetime) | timestamp_custom("%H:00"),
+                "title": as_timestamp(forecast['weather.home'].forecast[7].datetime) | timestamp_custom("%H:00"),
                 "condition": forecast['weather.home'].forecast[7].condition,
                 "temperature": forecast['weather.home'].forecast[7].temperature,
               },

--- a/components/espaper_dashboard_widgets/weather_widget.h
+++ b/components/espaper_dashboard_widgets/weather_widget.h
@@ -23,27 +23,51 @@ typedef enum {
     CONDITION_WINDY_VARIANT,
 } WeatherCondition;
 
+WeatherCondition str_to_condition_(std::string condition);
+std::string condition_to_icon_(WeatherCondition condition);
+std::string condition_to_icon_(std::string condition);
+
+struct WeatherStatus {
+    std::string title;
+    float temperature;
+    WeatherCondition condition;
+
+    WeatherStatus(std::string p_title, float p_temperature, WeatherCondition p_condition)
+        : title(std::move(p_title)), temperature(p_temperature), condition(p_condition)
+    {}
+
+    WeatherStatus(std::string p_title, float p_temperature, std::string p_condition)
+        : title(std::move(p_title)), temperature(p_temperature), condition(str_to_condition_(p_condition))
+    {}
+
+    WeatherStatus(const WeatherStatus& other)
+        : title(std::move(other.title)), temperature(other.temperature), condition(other.condition)
+    {}
+
+    WeatherStatus(WeatherStatus&& other)
+        : title(std::move(other.title)), temperature(other.temperature), condition(other.condition)
+    {}
+
+    WeatherStatus& operator=(const WeatherStatus& other) = default;
+};
+
 class WeatherWidget : public espaper_dashboard::ESPaperDashboardWidget {
 public:
     void draw(int start_x, int start_y) override;
     void init_size() override;
     void dump_config() override;
 
-    void set_current_temperature_sensor(sensor::Sensor *sensor) { this->current_temperature_sensor_ = sensor; };
-    void set_current_condition_sensor(text_sensor::TextSensor *sensor) { this->current_condition_sensor_ = sensor; };
-    void set_forecast_sensor(text_sensor::TextSensor *sensor) { this->forecast_sensor_ = sensor; };
     void set_temperature_uom(std::string uom) { this->temperature_uom_ = uom; };
+    template<typename T> void set_current_temperature(T current_temperature) { this->current_temperature_ = current_temperature; };
+    template<typename T> void set_current_condition(T current_condition) { this->current_condition_ = current_condition; };
+    template<typename T> void set_forecast(T forecast) { this->forecast_ = forecast; };
 
 protected:
-    sensor::Sensor *current_temperature_sensor_{nullptr};
-    text_sensor::TextSensor *current_condition_sensor_{nullptr};
-    text_sensor::TextSensor *forecast_sensor_{nullptr};
     std::string temperature_uom_{""};
+    TemplatableValue<float> current_temperature_{};
+    TemplatableValue<std::string> current_condition_{};
+    TemplatableValue<std::vector<WeatherStatus>> forecast_{};
 };
-
-WeatherCondition str_to_condition_(std::string condition);
-std::string condition_to_icon_(WeatherCondition condition);
-std::string condition_to_icon_(std::string condition);
 
 } // namespace espaper_dashboard_widgets
 } // namespace esphome

--- a/config/espaper-dashboard.yaml
+++ b/config/espaper-dashboard.yaml
@@ -88,9 +88,19 @@ espaper_dashboard:
       message: !lambda 'return "Downpour expected";'
     - id: weather_today
       type: weather
-      current_condition_sensor_id: weather_current_condition
-      current_temperature_sensor_id: weather_current_temperature
-      forecast_sensor_id: weather_hourly_forecast
+      current_condition: !lambda "return id(weather_current_condition).state;"
+      current_temperature: 21 # !lambda "return id(weather_current_temperature).state;"
+      # forecast:
+      #   - title: 1
+      #     temperature: 23.3
+      #     condition: lightning
+      forecast: !lambda |-
+        std::vector<espaper_dashboard_widgets::WeatherStatus> v{
+          espaper_dashboard_widgets::WeatherStatus("now", 23.3, "lightning"),
+          espaper_dashboard_widgets::WeatherStatus("soon", 21.7, "lightning-rainy"),
+          espaper_dashboard_widgets::WeatherStatus("later", 20.1, "partlycloudy")
+        };
+        return v;
       priority: 2
 
 sensor:


### PR DESCRIPTION
Fix #4

Add templatable fields to weather widget

```yaml
  ...
  widgets:
    - type: weather
      current_temperature: !lambda 'return 21.3;' # or simply current_temperature: 21.3
      current_condition: !lambda 'return id(condition).state;' # or simply current_condition: sunny
      forecast:
        - title: now
          temperature: 21.3
          condition: sunny
        - title: later
          temperature: 19.8
          condition: partlycloudy
```