### PR TITLE
Widget stale status

### DIFF
--- a/components/espaper_dashboard/__init__.py
+++ b/components/espaper_dashboard/__init__.py
@@ -1,6 +1,7 @@
 from collections.abc import Callable
 from typing import Any
 
+from esphome import automation
 import esphome.codegen as cg
 from esphome.components import display
 import esphome.config_validation as cv
@@ -30,6 +31,10 @@ CONF_WIDGETS = "widgets"
 espaper_dashboard_ns = cg.esphome_ns.namespace("espaper_dashboard")
 ESPaperDashboard = espaper_dashboard_ns.class_("ESPaperDashboard", cg.Component)
 ESPaperDashboardWidget = espaper_dashboard_ns.class_("ESPaperDashboardWidget")
+
+ESPaperDashboardWidgetMarkStaleAction = espaper_dashboard_ns.class_(
+    "ESPaperDashboardWidgetMarkStaleAction", automation.Action
+)
 
 
 class WidgetData:
@@ -184,3 +189,25 @@ async def to_code(config):
 
     for widget_conf in config[CONF_WIDGETS]:
         await supported_widgets.to_code(var, widget_conf)
+
+
+CONF_WIDGET_ID = "widget_id"
+ESPAPER_DASHBOARD_MARK_STALE_ACTION_SCHEMA = cv.maybe_simple_value(
+    {
+        cv.GenerateID(CONF_WIDGET_ID): cv.use_id(ESPaperDashboardWidget),
+    },
+    key=CONF_WIDGET_ID,
+)
+
+
+@automation.register_action(
+    "espaper_dashboard_widget.mark_stale",
+    ESPaperDashboardWidgetMarkStaleAction,
+    ESPAPER_DASHBOARD_MARK_STALE_ACTION_SCHEMA,
+)
+async def espaper_dashboard_widget_mark_stale_to_code(
+    config, action_id, template_arg, args
+):
+    parent = await cg.get_variable(config[CONF_WIDGET_ID])
+    var = cg.new_Pvariable(action_id, template_arg, parent)
+    return var

--- a/components/espaper_dashboard/automation.h
+++ b/components/espaper_dashboard/automation.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "espaper_dashboard_widget.h"
+
+namespace esphome {
+namespace espaper_dashboard {
+
+template<typename... Ts> class ESPaperDashboardWidgetMarkStaleAction : public Action<Ts...> {
+ public:
+  explicit ESPaperDashboardWidgetMarkStaleAction(ESPaperDashboardWidget *widget) : widget_(widget) {}
+
+  void play(Ts... x) override {
+    this->widget_->mark_stale();
+  }
+
+ protected:
+  ESPaperDashboardWidget *widget_;
+};
+
+} // namespace espaper_dashboard
+} // namespace esphome

--- a/components/espaper_dashboard/espaper_dashboard.cpp
+++ b/components/espaper_dashboard/espaper_dashboard.cpp
@@ -47,7 +47,7 @@ void ESPaperDashboard::draw() {
         if(total_height + widget->get_height() > this->display_->get_height()) break;
         if(!widget->should_draw()) continue;
 
-        if(widget->is_stale()) {
+        if(widget->needs_redraw()) {
             should_redraw = true;
             break;
         }
@@ -58,13 +58,17 @@ void ESPaperDashboard::draw() {
         ESP_LOGD(TAG, "No widget needs to be redrawn, skipping.");
         return;
     }
+    ESP_LOGD(TAG, "Redrawing ESPaper dashboard.");
 
     total_height = 0;
     this->display_->fill(this->get_background_color());
     for(auto widget : sorted_widgets) {
         App.feed_wdt();
         if(total_height + widget->get_height() > this->display_->get_height()) break;
-        if(!widget->should_draw()) continue;
+        if(!widget->should_draw()) {
+            widget->mark_not_drawn();
+            continue;
+        }
 
         this->display_->start_clipping(0, total_height, widget->get_width(), total_height+widget->get_height());
         widget->draw(0, total_height);

--- a/components/espaper_dashboard/espaper_dashboard_widget.cpp
+++ b/components/espaper_dashboard/espaper_dashboard_widget.cpp
@@ -12,6 +12,7 @@ namespace espaper_dashboard {
 static const char *TAG = "espaper_dashboard.widget";
 
 void ESPaperDashboardWidget::draw(int start_x, int start_y) {
+    this->was_drawn_ = true;
     this->is_stale_ = false;
     this->internal_draw(start_x, start_y);
 }
@@ -20,6 +21,10 @@ bool ESPaperDashboardWidget::should_draw() {
     if (this->should_draw_.has_value())
         return this->should_draw_.value();
     return true;
+}
+
+bool ESPaperDashboardWidget::needs_redraw() {
+    return this->is_stale() || (this->was_drawn_ != this->should_draw());
 }
 
 }

--- a/components/espaper_dashboard/espaper_dashboard_widget.cpp
+++ b/components/espaper_dashboard/espaper_dashboard_widget.cpp
@@ -23,6 +23,19 @@ bool ESPaperDashboardWidget::should_draw() {
     return true;
 }
 
+int ESPaperDashboardWidget::get_priority()  {
+    if(this->priority_.has_value()) {
+        int priority = this->priority_.value();
+        ESP_LOGD(TAG, "Old prio: %d, new prio: %d", this->old_priority_, priority); // DELETE ME
+        if(this->old_priority_ != priority) {
+            this->mark_stale();
+            this->old_priority_ = priority;
+        }
+        return priority;
+    }
+    return 0;
+}
+
 bool ESPaperDashboardWidget::needs_redraw() {
     return this->is_stale() || (this->was_drawn_ != this->should_draw());
 }

--- a/components/espaper_dashboard/espaper_dashboard_widget.cpp
+++ b/components/espaper_dashboard/espaper_dashboard_widget.cpp
@@ -11,6 +11,11 @@ namespace espaper_dashboard {
 
 static const char *TAG = "espaper_dashboard.widget";
 
+void ESPaperDashboardWidget::draw(int start_x, int start_y) {
+    this->is_stale_ = false;
+    this->internal_draw(start_x, start_y);
+}
+
 bool ESPaperDashboardWidget::should_draw() {
     if (this->should_draw_.has_value())
         return this->should_draw_.value();

--- a/components/espaper_dashboard/espaper_dashboard_widget.h
+++ b/components/espaper_dashboard/espaper_dashboard_widget.h
@@ -22,7 +22,7 @@ public:
     template<typename T> void set_should_draw(T should_draw) { this->should_draw_ = should_draw; };
     bool should_draw();
     template<typename T> void set_priority(T priority) { this->priority_ = priority; };
-    int get_priority() { return this->priority_.value(); };
+    int get_priority();
 
     bool is_stale() { return this->is_stale_; };
     void mark_stale() { this->is_stale_ = true; };
@@ -41,6 +41,9 @@ protected:
     display::Display *get_display_() { return this->target_->get_display(); };
     bool is_stale_{true};
     bool was_drawn_{false};
+
+private:
+    int old_priority_{0};
 };
 
 } // namespace espaper_dashboard

--- a/components/espaper_dashboard/espaper_dashboard_widget.h
+++ b/components/espaper_dashboard/espaper_dashboard_widget.h
@@ -37,7 +37,7 @@ protected:
     TemplatableValue<int> priority_{};
 
     display::Display *get_display_() { return this->target_->get_display(); };
-    bool is_stale_{false};
+    bool is_stale_{true};
 };
 
 } // namespace espaper_dashboard

--- a/components/espaper_dashboard/espaper_dashboard_widget.h
+++ b/components/espaper_dashboard/espaper_dashboard_widget.h
@@ -26,6 +26,8 @@ public:
 
     bool is_stale() { return this->is_stale_; };
     void mark_stale() { this->is_stale_ = true; };
+    void mark_not_drawn() { this->was_drawn_ = false; };
+    bool needs_redraw();
 
 protected:
     virtual void internal_draw(int start_x, int start_y) = 0;
@@ -38,6 +40,7 @@ protected:
 
     display::Display *get_display_() { return this->target_->get_display(); };
     bool is_stale_{true};
+    bool was_drawn_{false};
 };
 
 } // namespace espaper_dashboard

--- a/components/espaper_dashboard/espaper_dashboard_widget.h
+++ b/components/espaper_dashboard/espaper_dashboard_widget.h
@@ -10,7 +10,7 @@ namespace espaper_dashboard {
 
 class ESPaperDashboardWidget {
 public:
-    virtual void draw(int start_x, int start_y) = 0;
+    void draw(int start_x, int start_y);
     virtual void init_size() = 0;
     virtual void dump_config() = 0;
 
@@ -28,6 +28,8 @@ public:
     void mark_stale() { this->is_stale_ = true; };
 
 protected:
+    virtual void internal_draw(int start_x, int start_y) = 0;
+
     ESPaperDashboard *target_{nullptr};
     TemplatableValue<int> width_{0};
     TemplatableValue<int> height_{0};

--- a/components/espaper_dashboard/espaper_dashboard_widget.h
+++ b/components/espaper_dashboard/espaper_dashboard_widget.h
@@ -24,6 +24,9 @@ public:
     template<typename T> void set_priority(T priority) { this->priority_ = priority; };
     int get_priority() { return this->priority_.value(); };
 
+    bool is_stale() { return this->is_stale_; };
+    void mark_stale() { this->is_stale_ = true; };
+
 protected:
     ESPaperDashboard *target_{nullptr};
     TemplatableValue<int> width_{0};
@@ -32,6 +35,7 @@ protected:
     TemplatableValue<int> priority_{};
 
     display::Display *get_display_() { return this->target_->get_display(); };
+    bool is_stale_{false};
 };
 
 } // namespace espaper_dashboard

--- a/components/espaper_dashboard_widgets/custom_widget.cpp
+++ b/components/espaper_dashboard_widgets/custom_widget.cpp
@@ -6,14 +6,6 @@ namespace espaper_dashboard_widgets {
 
 static const char *TAG = "espaper_dashboard_widgets.custom_widget";
 
-void CustomWidget::draw(int start_x, int start_y) {
-    display::Display *it = this->get_display_();
-
-    if(this->lambda_.has_value()) {
-        (*this->lambda_)(*it, start_x, start_y);
-    }
-}
-
 void CustomWidget::init_size() {
     if(!this->width_.has_value() || !this->width_.value()) this->width_ = this->get_display_()->get_width();
     if(!this->height_.has_value() || !this->height_.value()) this->height_ = this->width_.value()/4;
@@ -21,6 +13,14 @@ void CustomWidget::init_size() {
 
 void CustomWidget::dump_config() {
     ESP_LOGCONFIG(TAG, "  Custom widget");
+}
+
+void CustomWidget::internal_draw(int start_x, int start_y) {
+    display::Display *it = this->get_display_();
+
+    if(this->lambda_.has_value()) {
+        (*this->lambda_)(*it, start_x, start_y);
+    }
 }
 
 }

--- a/components/espaper_dashboard_widgets/custom_widget.h
+++ b/components/espaper_dashboard_widgets/custom_widget.h
@@ -9,13 +9,14 @@ typedef std::function<void(display::Display &, int, int)> custom_widget_writer_t
 
 class CustomWidget : public espaper_dashboard::ESPaperDashboardWidget {
 public:
-    void draw(int start_x, int start_y) override;
     void init_size() override;
     void dump_config() override;
 
     void set_lambda(custom_widget_writer_t &&lambda_) { this->lambda_ = lambda_; }
 
 protected:
+    void internal_draw(int start_x, int start_y) override;
+
     optional<custom_widget_writer_t> lambda_{};
 };
 

--- a/components/espaper_dashboard_widgets/message_widget.cpp
+++ b/components/espaper_dashboard_widgets/message_widget.cpp
@@ -8,7 +8,16 @@ namespace espaper_dashboard_widgets {
 
 static const char *TAG = "espaper_dashboard_widgets.message_widget";
 
-void MessageWidget::draw(int start_x, int start_y) {
+void MessageWidget::init_size() {
+    if(!this->width_.has_value() || !this->width_.value()) this->width_ = this->get_display_()->get_width();
+    if(!this->height_.has_value() || !this->height_.value()) this->height_ = this->width_.value()/4;
+}
+
+void MessageWidget::dump_config() {
+    ESP_LOGCONFIG(TAG, "  Message widget");
+}
+
+void MessageWidget::internal_draw(int start_x, int start_y) {
     display::Display *it = this->get_display_();
 
 
@@ -22,15 +31,6 @@ void MessageWidget::draw(int start_x, int start_y) {
         it->printf(start_x+this->width_.value()/10, start_y+this->height_.value()/2, this->target_->get_large_font(), this->target_->get_foreground_color(), display::TextAlign::CENTER_LEFT, "%s", this->message_.value().c_str());
     }
 
-}
-
-void MessageWidget::init_size() {
-    if(!this->width_.has_value() || !this->width_.value()) this->width_ = this->get_display_()->get_width();
-    if(!this->height_.has_value() || !this->height_.value()) this->height_ = this->width_.value()/4;
-}
-
-void MessageWidget::dump_config() {
-    ESP_LOGCONFIG(TAG, "  Message widget");
 }
 
 }

--- a/components/espaper_dashboard_widgets/message_widget.h
+++ b/components/espaper_dashboard_widgets/message_widget.h
@@ -7,7 +7,6 @@ namespace espaper_dashboard_widgets {
 
 class MessageWidget : public espaper_dashboard::ESPaperDashboardWidget {
 public:
-    void draw(int start_x, int start_y) override;
     void init_size() override;
     void dump_config() override;
 
@@ -15,6 +14,8 @@ public:
     template<typename T> void set_message(T message) { this->message_ = message; };
 
 protected:
+    void internal_draw(int start_x, int start_y) override;
+
     TemplatableValue<std::string> icon_{};
     TemplatableValue<std::string> message_{};
 };

--- a/components/espaper_dashboard_widgets/weather_widget.cpp
+++ b/components/espaper_dashboard_widgets/weather_widget.cpp
@@ -9,36 +9,6 @@ namespace espaper_dashboard_widgets {
 
 static const char *TAG = "espaper_dashboard_widgets.weather_widget";
 
-void WeatherWidget::draw(int start_x, int start_y) {
-    display::Display *it = this->get_display_();
-
-    // current condition icon
-    it->printf(start_x+this->width_.value()/3, start_y+this->height_.value()/4, this->target_->get_large_glyph_font(), this->target_->get_light_color(), display::TextAlign::CENTER_RIGHT, "%s", condition_to_icon_(this->current_condition_.value()).c_str());
-    // current temperature UOM
-    it->printf(start_x+this->width_.value()/2, start_y+this->height_.value()/4, this->target_->get_large_font(), this->target_->get_dark_color(), display::TextAlign::CENTER_LEFT, "%.1f%s", this->current_temperature_.value(), this->temperature_uom_.c_str());
-    // current temperature
-    it->printf(start_x+this->width_.value()/2, start_y+this->height_.value()/4, this->target_->get_large_font(), this->target_->get_foreground_color(), display::TextAlign::CENTER_LEFT, "%.1f", this->current_temperature_.value());
-
-    std::vector<WeatherStatus> forecast = this->forecast_.value();
-
-    int i=1, n=(forecast.size()+2)*2;
-    for(const WeatherStatus& interval : forecast) {
-        // forcast timespan
-        it->printf((i*2+1)*this->width_.value()/n, start_y+this->height_.value()/2, this->target_->get_default_font(), this->target_->get_dark_color(), display::TextAlign::TOP_CENTER, "%s", interval.title.c_str());
-        // forecast condition icon
-        it->printf((i*2+1)*this->width_.value()/n, start_y+2*this->height_.value()/3, this->target_->get_glyph_font(), this->target_->get_light_color(), display::TextAlign::TOP_CENTER, "%s", condition_to_icon_(interval.condition).c_str());
-        // forecast temperature UOM
-        int x, y, w, h;
-        char t[20];
-        sprintf(t, "%.1f%s", interval.temperature, this->temperature_uom_.c_str());
-        it->get_text_bounds(start_x+(i*2+1)*this->width_.value()/n, start_y+5*this->height_.value()/6, t, this->target_->get_default_font(), display::TextAlign::TOP_CENTER, &x, &y, &w, &h);
-        it->printf(x, y, this->target_->get_default_font(), this->target_->get_dark_color(), display::TextAlign::TOP_LEFT, "%.1f%s", interval.temperature, this->temperature_uom_.c_str());
-        // forecast temperature
-        it->printf(x, y, this->target_->get_default_font(), this->target_->get_foreground_color(), display::TextAlign::TOP_LEFT, "%.1f", interval.temperature);
-        i++;
-    }
-}
-
 void WeatherWidget::init_size() {
     if(!this->width_.has_value() || !this->width_.value()) this->width_ = this->get_display_()->get_width();
     if(!this->height_.has_value() || !this->height_.value()) this->height_ = this->width_.value()*7/16;
@@ -96,6 +66,36 @@ std::string condition_to_icon_(std::string condition) {
     return condition_to_icon_(str_to_condition_(condition));
 
 
+}
+
+void WeatherWidget::internal_draw(int start_x, int start_y) {
+    display::Display *it = this->get_display_();
+
+    // current condition icon
+    it->printf(start_x+this->width_.value()/3, start_y+this->height_.value()/4, this->target_->get_large_glyph_font(), this->target_->get_light_color(), display::TextAlign::CENTER_RIGHT, "%s", condition_to_icon_(this->current_condition_.value()).c_str());
+    // current temperature UOM
+    it->printf(start_x+this->width_.value()/2, start_y+this->height_.value()/4, this->target_->get_large_font(), this->target_->get_dark_color(), display::TextAlign::CENTER_LEFT, "%.1f%s", this->current_temperature_.value(), this->temperature_uom_.c_str());
+    // current temperature
+    it->printf(start_x+this->width_.value()/2, start_y+this->height_.value()/4, this->target_->get_large_font(), this->target_->get_foreground_color(), display::TextAlign::CENTER_LEFT, "%.1f", this->current_temperature_.value());
+
+    std::vector<WeatherStatus> forecast = this->forecast_.value();
+
+    int i=1, n=(forecast.size()+2)*2;
+    for(const WeatherStatus& interval : forecast) {
+        // forcast timespan
+        it->printf((i*2+1)*this->width_.value()/n, start_y+this->height_.value()/2, this->target_->get_default_font(), this->target_->get_dark_color(), display::TextAlign::TOP_CENTER, "%s", interval.title.c_str());
+        // forecast condition icon
+        it->printf((i*2+1)*this->width_.value()/n, start_y+2*this->height_.value()/3, this->target_->get_glyph_font(), this->target_->get_light_color(), display::TextAlign::TOP_CENTER, "%s", condition_to_icon_(interval.condition).c_str());
+        // forecast temperature UOM
+        int x, y, w, h;
+        char t[20];
+        sprintf(t, "%.1f%s", interval.temperature, this->temperature_uom_.c_str());
+        it->get_text_bounds(start_x+(i*2+1)*this->width_.value()/n, start_y+5*this->height_.value()/6, t, this->target_->get_default_font(), display::TextAlign::TOP_CENTER, &x, &y, &w, &h);
+        it->printf(x, y, this->target_->get_default_font(), this->target_->get_dark_color(), display::TextAlign::TOP_LEFT, "%.1f%s", interval.temperature, this->temperature_uom_.c_str());
+        // forecast temperature
+        it->printf(x, y, this->target_->get_default_font(), this->target_->get_foreground_color(), display::TextAlign::TOP_LEFT, "%.1f", interval.temperature);
+        i++;
+    }
 }
 
 }

--- a/components/espaper_dashboard_widgets/weather_widget.h
+++ b/components/espaper_dashboard_widgets/weather_widget.h
@@ -53,7 +53,6 @@ struct WeatherStatus {
 
 class WeatherWidget : public espaper_dashboard::ESPaperDashboardWidget {
 public:
-    void draw(int start_x, int start_y) override;
     void init_size() override;
     void dump_config() override;
 
@@ -63,6 +62,8 @@ public:
     template<typename T> void set_forecast(T forecast) { this->forecast_ = forecast; };
 
 protected:
+    void internal_draw(int start_x, int start_y) override;
+
     std::string temperature_uom_{""};
     TemplatableValue<float> current_temperature_{};
     TemplatableValue<std::string> current_condition_{};


### PR DESCRIPTION
Allow dashboard to only update when widgets change:
- when their visibility changes
- when they are visible and their priority changes
- when they are manually marked as stale

Example implementation:

```yaml
sensor:
  - id: external_sensor
    platform: homeassistant
    entity_id: sensor.my_sensor
    on_value:
      then:
        - espaper_dashboard_widget.mark_stale: widget_using_sensor

espaper_dashboard:
  ...
  widgets:
    - id: widget_using_sensor
      ...
```